### PR TITLE
修正公式 3.18

### DIFF
--- a/source/partI/chapter3/finite_markov_decision_process.rst
+++ b/source/partI/chapter3/finite_markov_decision_process.rst
@@ -624,7 +624,7 @@ MDP框架是从相互作用的目标导向学习的问题中抽象出来的。
 
     \begin{align*}
     q_*(s,a) &= \mathbb{E}\left[R_{t+1}+\gamma\sum_{a^\prime}q_*(S_{t+1,a^\prime})|S_t=s,A_t=a\right] \\
-    &=\sum_{s^\prime,r}p(s^\prime,r|s,a)[r+\gamma \sum_{a^\prime}q_*(s^\prime,a^\prime)]
+    &=\sum_{s^\prime,r}p(s^\prime,r|s,a)[r+\gamma \max_{a^\prime}q_*(s^\prime,a^\prime)]
     \end{align*}
 
 下图中的备份图以图像方式显示了在 :math:`v_*` 和 :math:`q_*` 的贝尔曼最优方程中考虑的未来状态和动作的跨度。


### PR DESCRIPTION
`\sum_{a^\prime}q_*(s^\prime,a^\prime)` should be `\max_{a^\prime}q_*(s^\prime,a^\prime)`

![image](https://user-images.githubusercontent.com/40143136/97079537-51645e80-1627-11eb-92d1-fa10ac0f8773.png)

![image](https://user-images.githubusercontent.com/40143136/97079557-8a043800-1627-11eb-864e-05d5d2cbb6c9.png)
